### PR TITLE
Increase memory for controller-manager

### DIFF
--- a/bundle/manifests/mariadb-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/mariadb-operator.clusterserviceversion.yaml
@@ -511,10 +511,10 @@ spec:
                     resources:
                       limits:
                         cpu: 500m
-                        memory: 128Mi
+                        memory: 256Mi
                       requests:
                         cpu: 10m
-                        memory: 64Mi
+                        memory: 128Mi
                     securityContext:
                       allowPrivilegeEscalation: false
                       capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -93,9 +93,9 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 128Mi
+              memory: 256Mi
             requests:
               cpu: 10m
-              memory: 64Mi
+              memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
After using mariadb-operator-helm to install mariadb-operator on OpenShift I noticed the controller-manager was OOMKilled several times. As I gathered more information I found #6 and https://github.com/mariadb-operator/mariadb-operator-helm/issues/4#issuecomment-1609028768 that had the same experience. 

Would it be possible to increase memory limits by default? Thanks!